### PR TITLE
Bugfix: use virtual environment for python interface

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,6 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        shared-libs: [ON, OFF]
 
     env:
       BUILD_TYPE: Release
@@ -28,7 +27,7 @@ jobs:
     - name: install dependencies
       run: conan install . --build=missing -s build_type=${{ env.BUILD_TYPE }}
     - name: cmake
-      run: cmake . -DCMAKE_TOOLCHAIN_FILE="conan_toolchain.cmake" -DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DBUILD_SHARED_LIBS=${{ matrix.shared-libs }}
+      run: cmake . -DCMAKE_TOOLCHAIN_FILE="conan_toolchain.cmake" -DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON
     - name: cmake build
       run: cmake --build . --config ${{ env.BUILD_TYPE }}
     - name: ctest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
+        shared-libs: [ON, OFF]
 
     env:
       BUILD_TYPE: Release
@@ -27,7 +28,7 @@ jobs:
     - name: install dependencies
       run: conan install . --build=missing -s build_type=${{ env.BUILD_TYPE }}
     - name: cmake
-      run: cmake . -DCMAKE_TOOLCHAIN_FILE="conan_toolchain.cmake" -DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON
+      run: cmake . -DCMAKE_TOOLCHAIN_FILE="conan_toolchain.cmake" -DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DBUILD_SHARED_LIBS=${{ matrix.shared-libs }}
     - name: cmake build
       run: cmake --build . --config ${{ env.BUILD_TYPE }}
     - name: ctest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,28 +42,26 @@ endif()
 if(ENABLE_PYTHON)
   # Needed a shared library for cppyy package used for the python interface
   if(${BUILD_SHARED_LIBS})
-    find_package(Python2 COMPONENTS Interpreter Development)
     find_package(Python3 COMPONENTS Interpreter Development)
+    set(GM2CALC_VENV "${PROJECT_BINARY_DIR}/gm2calc-venv")
+    execute_process(COMMAND "${Python3_EXECUTABLE}" -m venv "${GM2CALC_VENV}" OUTPUT_QUIET)
+    set(ENV{VIRTUAL_ENV} "${GM2CALC_VENV}")
+    set(Python3_FIND_VIRTUALENV FIRST)
+    unset(Python3_EXECUTABLE)
+    find_package(Python3 COMPONENTS Interpreter Development)
+    # python executable in the virtual environment
+    set(PYTHON_EXE "${GM2CALC_VENV}/bin/python")
   else()
     message("-- Python interface requires a shared library to be built.  Use the option -DBUILD_SHARED_LIBS=ON to enable.")
   endif()
 endif()
 
-if(Python2_FOUND)
-  execute_process(
-    COMMAND ${Python2_EXECUTABLE} -c "import cppyy"
-    RESULT_VARIABLE PYTHON2_HAS_cppyy
-    OUTPUT_QUIET)
-  if(NOT ${PYTHON2_HAS_cppyy} EQUAL 0)
-    message("-- Python2 does not have cppyy.  cppyy module is required for python interface.")
-  else()
-    set(Python_INTERFACE 1)
-  endif()
-endif()
-
 if(Python3_FOUND)
   execute_process(
-    COMMAND ${Python3_EXECUTABLE} -c "import cppyy"
+    COMMAND "${PYTHON_EXE}" -m pip install cppyy
+    OUTPUT_QUIET)
+  execute_process(
+    COMMAND "${PYTHON_EXE}" -c "import cppyy"
     RESULT_VARIABLE PYTHON3_HAS_cppyy
     OUTPUT_QUIET)
   if(NOT ${PYTHON3_HAS_cppyy} EQUAL 0)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,15 @@ string(REGEX REPLACE "^#define[ \t]+GM2CALC_VERSION[ \t]+\"([0-9.]+)\"$" "\\1" G
 
 find_package(Boost 1.37.0 REQUIRED)
 find_package(Eigen3 3.1 REQUIRED NO_MODULE)
+
+# conan's Eigen3 package defines Eigen3_INCLUDE_DIR instead of
+# EIGEN3_INCLUDE_DIR
+if(NOT DEFINED EIGEN3_INCLUDE_DIR)
+  if(DEFINED Eigen3_INCLUDE_DIR)
+    set(EIGEN3_INCLUDE_DIR "${Eigen3_INCLUDE_DIR}")
+  endif()
+endif()
+
 if(ENABLE_MATHEMATICA)
   find_package(Mathematica COMPONENTS MathLink)
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -74,13 +74,13 @@ if(Python_INTERFACE)
                  @ONLY)
   add_test(
     NAME test_THDM_python_interface
-    COMMAND ${Python3_EXECUTABLE} test_THDM_python_interface.py 
+    COMMAND "${PYTHON_EXE}" test_THDM_python_interface.py
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
   configure_file(${PROJECT_SOURCE_DIR}/test/test_MSSMNoFV_python_interface.py.in 
                  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test_MSSMNoFV_python_interface.py 
                  @ONLY)
   add_test(
     NAME test_MSSMNoFV_python_interface
-    COMMAND ${Python3_EXECUTABLE} test_MSSMNoFV_python_interface.py 
+    COMMAND "${PYTHON_EXE}" test_MSSMNoFV_python_interface.py
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 endif()


### PR DESCRIPTION
Fixes python interface on Debian/Ubuntu systems, where cppyy cannot be installed via pip.

This PR also removes the deprecated Python-2 interface.